### PR TITLE
feat: LLM priority ranking per profile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "proof-queue",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "express": "^5.2.1",
         "uuid": "^13.0.0",
       },
@@ -20,6 +21,10 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
     "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
@@ -114,6 +119,8 @@
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
@@ -167,6 +174,8 @@
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
     "express": "^5.2.1",
     "uuid": "^13.0.0"
   }

--- a/server/ranking/profiles.ts
+++ b/server/ranking/profiles.ts
@@ -1,0 +1,14 @@
+export interface ProfileContext {
+  name: string;
+  focus: string;
+}
+
+export const PROFILES: Record<string, ProfileContext> = {
+  sre: { name: "SRE", focus: "production incidents, reliability, on-call urgency" },
+  quant: { name: "Quant", focus: "data integrity, model correctness, market impact" },
+  developer: { name: "Developer", focus: "code bugs, unblocking tasks, technical debt" },
+  pm: { name: "PM", focus: "user impact, delivery, stakeholder communication" },
+  user: { name: "User", focus: "feature requests, UX issues, account problems" },
+};
+
+export type ProfileName = keyof typeof PROFILES;

--- a/server/ranking/ranking-service.test.ts
+++ b/server/ranking/ranking-service.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from "bun:test";
+import { PROFILES } from "./profiles.ts";
+
+describe("profiles", () => {
+  test("all profiles have name and focus", () => {
+    for (const [key, profile] of Object.entries(PROFILES)) {
+      expect(profile.name).toBeTruthy();
+      expect(profile.focus).toBeTruthy();
+      expect(typeof profile.name).toBe("string");
+      expect(typeof profile.focus).toBe("string");
+    }
+  });
+
+  test("has expected profiles", () => {
+    expect(Object.keys(PROFILES).sort()).toEqual([
+      "developer",
+      "pm",
+      "quant",
+      "sre",
+      "user",
+    ]);
+  });
+});
+
+describe("parseResponse (unit)", () => {
+  // Test the parsing logic directly
+  function parseResponse(text: string) {
+    const match = text.match(/\[[\s\S]*\]/);
+    if (!match) throw new Error("No JSON array found in LLM response");
+    const parsed = JSON.parse(match[0]) as Array<{
+      threadId: string;
+      score: number;
+      reason: string;
+    }>;
+    return parsed
+      .map((entry) => ({
+        threadId: entry.threadId,
+        score: Math.max(0, Math.min(100, entry.score)),
+        reason: entry.reason,
+      }))
+      .sort((a, b) => b.score - a.score);
+  }
+
+  test("parses valid JSON response", () => {
+    const text = `[{"threadId":"a","score":90,"reason":"Critical"},{"threadId":"b","score":40,"reason":"Low"}]`;
+    const result = parseResponse(text);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.threadId).toBe("a");
+    expect(result[0]!.score).toBe(90);
+    expect(result[1]!.threadId).toBe("b");
+  });
+
+  test("extracts JSON from surrounding text", () => {
+    const text = `Here is the ranking:\n[{"threadId":"x","score":75,"reason":"Medium"}]\nDone.`;
+    const result = parseResponse(text);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.score).toBe(75);
+  });
+
+  test("clamps scores to 0-100", () => {
+    const text = `[{"threadId":"a","score":150,"reason":"Over"},{"threadId":"b","score":-10,"reason":"Under"}]`;
+    const result = parseResponse(text);
+    expect(result[0]!.score).toBe(100);
+    expect(result[1]!.score).toBe(0);
+  });
+
+  test("sorts by score descending", () => {
+    const text = `[{"threadId":"a","score":30,"reason":"Low"},{"threadId":"b","score":80,"reason":"High"},{"threadId":"c","score":50,"reason":"Mid"}]`;
+    const result = parseResponse(text);
+    expect(result.map((r) => r.threadId)).toEqual(["b", "c", "a"]);
+  });
+
+  test("throws on invalid response", () => {
+    expect(() => parseResponse("no json here")).toThrow("No JSON array found");
+  });
+});

--- a/server/ranking/ranking-service.ts
+++ b/server/ranking/ranking-service.ts
@@ -1,0 +1,132 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { Thread } from "../thread-store.ts";
+import { PROFILES, type ProfileName } from "./profiles.ts";
+import db from "../db/index.ts";
+
+export interface RankedEntry {
+  threadId: string;
+  score: number;
+  reason: string;
+}
+
+interface CacheEntry {
+  rankedEntries: RankedEntry[];
+  cachedAt: number;
+  threadFingerprint: string;
+}
+
+const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes
+const cache = new Map<string, CacheEntry>();
+
+const anthropic = new Anthropic();
+
+function buildFingerprint(threads: Thread[]): string {
+  return threads
+    .map((t) => `${t.id}:${t.updatedAt}`)
+    .sort()
+    .join("|");
+}
+
+function buildPrompt(threads: Thread[], profile: ProfileName): string {
+  const ctx = PROFILES[profile]!;
+  const threadList = threads
+    .map(
+      (t) =>
+        `- ID: ${t.id} | Title: "${t.title}" | Status: ${t.status} | Tags: [${t.tags.join(", ")}] | Created: ${t.createdAt}`
+    )
+    .join("\n");
+
+  return `You are a priority ranking assistant for a ${ctx.name} professional.
+Their focus areas are: ${ctx.focus}.
+
+Rank the following threads by priority for this profile. For each thread, assign a score from 0-100 (100 = most urgent) and a brief reason.
+
+Threads:
+${threadList}
+
+Respond with ONLY a JSON array, no other text. Each element must have:
+- "threadId": the thread ID
+- "score": number 0-100
+- "reason": brief explanation (max 20 words)
+
+Example: [{"threadId":"abc","score":85,"reason":"Production incident needs immediate attention"}]`;
+}
+
+function parseResponse(text: string): RankedEntry[] {
+  // Extract JSON array from response
+  const match = text.match(/\[[\s\S]*\]/);
+  if (!match) throw new Error("No JSON array found in LLM response");
+
+  const parsed = JSON.parse(match[0]) as Array<{
+    threadId: string;
+    score: number;
+    reason: string;
+  }>;
+
+  return parsed
+    .map((entry) => ({
+      threadId: entry.threadId,
+      score: Math.max(0, Math.min(100, entry.score)),
+      reason: entry.reason,
+    }))
+    .sort((a, b) => b.score - a.score);
+}
+
+export async function rankThreads(
+  threads: Thread[],
+  profile: ProfileName
+): Promise<RankedEntry[]> {
+  if (threads.length === 0) return [];
+
+  const fingerprint = buildFingerprint(threads);
+  const cacheKey = profile;
+  const cached = cache.get(cacheKey);
+
+  if (
+    cached &&
+    cached.threadFingerprint === fingerprint &&
+    Date.now() - cached.cachedAt < CACHE_TTL_MS
+  ) {
+    return cached.rankedEntries;
+  }
+
+  const prompt = buildPrompt(threads, profile);
+
+  const response = await anthropic.messages.create({
+    model: "claude-sonnet-4-20250514",
+    max_tokens: 1024,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const text =
+    response.content[0]?.type === "text" ? response.content[0].text : "";
+  const rankedEntries = parseResponse(text);
+
+  // Update cache
+  cache.set(cacheKey, {
+    rankedEntries,
+    cachedAt: Date.now(),
+    threadFingerprint: fingerprint,
+  });
+
+  // Persist priority cache per thread
+  const updateStmt = db.prepare(
+    "UPDATE threads SET priority_cache = ?, priority_cached_at = datetime('now') WHERE id = ?"
+  );
+  for (const entry of rankedEntries) {
+    updateStmt.run(
+      JSON.stringify({ score: entry.score, reason: entry.reason }),
+      entry.threadId
+    );
+  }
+
+  return rankedEntries;
+}
+
+export function invalidateCache(profile?: string): void {
+  if (profile) {
+    cache.delete(profile);
+  } else {
+    cache.clear();
+  }
+}

--- a/server/routes/threads.ts
+++ b/server/routes/threads.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { ProofClient } from "../proof-client.ts";
 import { ThreadStore } from "../thread-store.ts";
+import { rankThreads, invalidateCache } from "../ranking/ranking-service.ts";
+import { PROFILES, type ProfileName } from "../ranking/profiles.ts";
 
 const router = Router();
 const proofClient = new ProofClient();
@@ -48,6 +50,7 @@ router.post("/", async (req, res) => {
   }
 
   ThreadStore.addParticipant(thread.id, createdBy, "owner");
+  invalidateCache();
 
   res.status(201).json({
     ...thread,
@@ -55,10 +58,41 @@ router.post("/", async (req, res) => {
   });
 });
 
-// GET /api/threads — list all (optionally filter by status)
-router.get("/", (_req, res) => {
-  const status = _req.query.status as string | undefined;
+// GET /api/threads — list all, optionally ranked by profile
+router.get("/", async (req, res) => {
+  const status = req.query.status as string | undefined;
+  const profile = req.query.profile as string | undefined;
   const threads = ThreadStore.findAll(status);
+
+  if (profile) {
+    if (!(profile in PROFILES)) {
+      res.status(400).json({
+        error: `Invalid profile. Valid profiles: ${Object.keys(PROFILES).join(", ")}`,
+      });
+      return;
+    }
+
+    try {
+      const ranked = await rankThreads(threads, profile as ProfileName);
+      const rankMap = new Map(ranked.map((r) => [r.threadId, r]));
+      const result = threads
+        .map((t) => {
+          const rank = rankMap.get(t.id);
+          return {
+            ...t,
+            priority: rank
+              ? { score: rank.score, reason: rank.reason }
+              : { score: 0, reason: "unranked" },
+          };
+        })
+        .sort((a, b) => b.priority.score - a.priority.score);
+      res.json(result);
+    } catch (err) {
+      res.status(502).json({ error: "Ranking failed", details: String(err) });
+    }
+    return;
+  }
+
   res.json(threads);
 });
 
@@ -90,6 +124,7 @@ router.patch("/:id", (req, res) => {
   let updated = thread;
   if (status) updated = ThreadStore.updateStatus(thread.id, status) ?? thread;
   if (tags) updated = ThreadStore.updateTags(thread.id, tags) ?? updated;
+  invalidateCache();
 
   res.json(updated);
 });
@@ -103,6 +138,7 @@ router.delete("/:id", (req, res) => {
   }
 
   const closed = ThreadStore.close(thread.id);
+  invalidateCache();
   res.json(closed);
 });
 


### PR DESCRIPTION
## Summary
- Added `RankingService` that calls Claude API to rank threads by priority for a given profile
- Defined 5 profiles: `sre`, `quant`, `developer`, `pm`, `user` — each with domain-specific focus areas
- `GET /api/threads?profile=sre` returns threads sorted by LLM-assigned priority with `score` (0-100) and `reason`
- In-memory cache with 2-min TTL + thread fingerprint invalidation
- Cache cleared on any thread mutation (create/update/delete)

## Key Files
| File | Purpose |
|------|---------|
| `server/ranking/profiles.ts` | Profile definitions with focus areas |
| `server/ranking/ranking-service.ts` | LLM ranking + caching logic |
| `server/ranking/ranking-service.test.ts` | 7 tests for profiles + response parsing |
| `server/routes/threads.ts` | Updated GET endpoint with `?profile=` support |

## Test plan
- [ ] `bun test` — all tests pass (7 ranking + 6 thread store)
- [ ] `bun run typecheck` — no errors
- [ ] With `ANTHROPIC_API_KEY` set: `GET /api/threads?profile=sre` returns ranked threads
- [ ] Second request within 2 min uses cache (no LLM call)
- [ ] Creating/updating a thread invalidates the cache

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)