### PR TITLE
feat: event-driven agent trigger (event polling)

### DIFF
--- a/server/agents/event-poller.test.ts
+++ b/server/agents/event-poller.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect, beforeAll, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { migrate } from "../db/migrate.ts";
+
+// We test the EventPoller class directly with a mock ProofClient
+import { EventPoller, type ProofEvent } from "./event-poller.ts";
+import type { Thread } from "../thread-store.ts";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: "t1",
+    slug: "slug-1",
+    accessToken: "tok",
+    ownerSecret: "secret",
+    title: "Test Thread",
+    status: "open",
+    tags: [],
+    createdBy: "agent-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    lastEventId: 0,
+    priorityCache: null,
+    priorityCachedAt: null,
+    ...overrides,
+  };
+}
+
+describe("EventPoller", () => {
+  test("registers handlers", () => {
+    const poller = new EventPoller();
+    let called = false;
+    poller.onEvent(() => {
+      called = true;
+    });
+    // Handler registered but not called yet
+    expect(called).toBe(false);
+  });
+
+  test("start/stop thread tracking", () => {
+    const poller = new EventPoller();
+    const thread = makeThread();
+
+    poller.startThread(thread);
+    expect(poller.activeThreadIds).toContain("t1");
+
+    poller.stopThread("t1");
+    expect(poller.activeThreadIds).not.toContain("t1");
+  });
+
+  test("doesn't duplicate polling for same thread", () => {
+    const poller = new EventPoller();
+    const thread = makeThread();
+
+    poller.startThread(thread);
+    poller.startThread(thread); // duplicate
+    expect(poller.activeThreadIds).toHaveLength(1);
+
+    poller.stopAll();
+  });
+
+  test("stopAll clears all timers", () => {
+    const poller = new EventPoller();
+    poller.startThread(makeThread({ id: "a" }));
+    poller.startThread(makeThread({ id: "b" }));
+    expect(poller.activeThreadIds).toHaveLength(2);
+
+    poller.stopAll();
+    expect(poller.activeThreadIds).toHaveLength(0);
+  });
+});

--- a/server/agents/event-poller.ts
+++ b/server/agents/event-poller.ts
@@ -1,0 +1,126 @@
+import { ProofClient } from "../proof-client.ts";
+import { ThreadStore, type Thread } from "../thread-store.ts";
+
+export interface ProofEvent {
+  id: number;
+  type: string;
+  data: Record<string, unknown>;
+  actor: string;
+  createdAt: string;
+}
+
+export type AgentHandler = (thread: Thread, event: ProofEvent) => void | Promise<void>;
+
+const POLL_INTERVAL_MS = 5_000;
+
+export class EventPoller {
+  private proofClient: ProofClient;
+  private handlers: AgentHandler[] = [];
+  private timers = new Map<string, ReturnType<typeof setInterval>>();
+  private polling = new Map<string, boolean>();
+
+  constructor(proofClient?: ProofClient) {
+    this.proofClient = proofClient ?? new ProofClient();
+  }
+
+  /** Register an agent handler that will receive all events. */
+  onEvent(handler: AgentHandler): void {
+    this.handlers.push(handler);
+  }
+
+  /** Start polling for a single thread. */
+  startThread(thread: Thread): void {
+    if (this.timers.has(thread.id)) return; // already polling
+
+    const poll = async () => {
+      if (this.polling.get(thread.id)) return; // debounce
+      this.polling.set(thread.id, true);
+
+      try {
+        // Re-read thread to get latest lastEventId
+        const current = ThreadStore.findById(thread.id);
+        if (!current || current.status === "resolved") {
+          this.stopThread(thread.id);
+          return;
+        }
+
+        const result = await this.proofClient.getPendingEvents(
+          current.slug,
+          current.lastEventId
+        );
+
+        if (result.events.length === 0) return;
+
+        for (const event of result.events) {
+          for (const handler of this.handlers) {
+            try {
+              await handler(current, event as ProofEvent);
+            } catch (err) {
+              console.error(
+                `Handler error for event ${event.id} on thread ${current.id}:`,
+                err
+              );
+            }
+          }
+        }
+
+        // Persist the cursor
+        const maxEventId = Math.max(...result.events.map((e) => e.id));
+        ThreadStore.updateLastEventId(current.id, maxEventId);
+      } catch (err) {
+        console.error(`Poll error for thread ${thread.id}:`, err);
+      } finally {
+        this.polling.set(thread.id, false);
+      }
+    };
+
+    // Run immediately, then on interval
+    poll();
+    const timer = setInterval(poll, POLL_INTERVAL_MS);
+    this.timers.set(thread.id, timer);
+  }
+
+  /** Stop polling for a thread. */
+  stopThread(threadId: string): void {
+    const timer = this.timers.get(threadId);
+    if (timer) {
+      clearInterval(timer);
+      this.timers.delete(threadId);
+      this.polling.delete(threadId);
+    }
+  }
+
+  /** Start polling for all open threads. */
+  startAll(): void {
+    const threads = ThreadStore.findAllOpen();
+    for (const thread of threads) {
+      this.startThread(thread);
+    }
+    console.log(`EventPoller: started polling for ${threads.length} open threads`);
+  }
+
+  /** Stop all polling. */
+  stopAll(): void {
+    for (const threadId of this.timers.keys()) {
+      this.stopThread(threadId);
+    }
+  }
+
+  /** Get the set of thread IDs being polled. */
+  get activeThreadIds(): string[] {
+    return [...this.timers.keys()];
+  }
+}
+
+// Singleton for use across modules
+let _instance: EventPoller | null = null;
+
+export function initEventPoller(proofClient?: ProofClient): EventPoller {
+  _instance = new EventPoller(proofClient);
+  return _instance;
+}
+
+export function getEventPoller(): EventPoller {
+  if (!_instance) throw new Error("EventPoller not initialized");
+  return _instance;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import { ProofClient } from "./proof-client.ts";
-import threadRoutes from "./routes/threads.ts";
+import { initEventPoller, getEventPoller } from "./agents/event-poller.ts";
 
 // Initialize DB (runs migrations on import)
 import "./db/index.ts";
@@ -9,15 +9,26 @@ const app = express();
 const PORT = Number.parseInt(process.env.PORT ?? "3000", 10);
 const proofClient = new ProofClient();
 
+initEventPoller(proofClient);
+
+// Import routes after poller is initialized
+const { default: threadRoutes } = await import("./routes/threads.ts");
+
 app.use(express.json());
 
 app.get("/health", async (_req, res) => {
   const proofSdkReachable = await proofClient.isReachable();
-  res.json({ ok: true, proofSdkReachable });
+  const poller = getEventPoller();
+  res.json({
+    ok: true,
+    proofSdkReachable,
+    activePollers: poller.activeThreadIds.length,
+  });
 });
 
 app.use("/api/threads", threadRoutes);
 
 app.listen(PORT, () => {
   console.log(`proof-queue listening on http://localhost:${PORT}`);
+  getEventPoller().startAll();
 });

--- a/server/routes/threads.ts
+++ b/server/routes/threads.ts
@@ -3,6 +3,7 @@ import { ProofClient } from "../proof-client.ts";
 import { ThreadStore } from "../thread-store.ts";
 import { rankThreads, invalidateCache } from "../ranking/ranking-service.ts";
 import { PROFILES, type ProfileName } from "../ranking/profiles.ts";
+import { getEventPoller } from "../agents/event-poller.ts";
 
 const router = Router();
 const proofClient = new ProofClient();
@@ -51,6 +52,9 @@ router.post("/", async (req, res) => {
 
   ThreadStore.addParticipant(thread.id, createdBy, "owner");
   invalidateCache();
+
+  // Start polling for events on the new thread
+  getEventPoller().startThread(thread);
 
   res.status(201).json({
     ...thread,
@@ -139,6 +143,7 @@ router.delete("/:id", (req, res) => {
 
   const closed = ThreadStore.close(thread.id);
   invalidateCache();
+  getEventPoller().stopThread(thread.id);
   res.json(closed);
 });
 

--- a/server/thread-store.ts
+++ b/server/thread-store.ts
@@ -125,4 +125,25 @@ export const ThreadStore = {
       .query("SELECT * FROM participants WHERE thread_id = ?")
       .all(threadId) as Participant[];
   },
+
+  updateLastEventId(id: string, lastEventId: number): void {
+    db.run(
+      "UPDATE threads SET last_event_id = ?, updated_at = datetime('now') WHERE id = ?",
+      [lastEventId, id]
+    );
+  },
+
+  findAllOpen(): Thread[] {
+    const rows = db
+      .query("SELECT * FROM threads WHERE status IN ('open', 'in_progress') ORDER BY updated_at DESC")
+      .all() as Record<string, unknown>[];
+    return rows.map(rowToThread);
+  },
+
+  findBySlug(slug: string): Thread | undefined {
+    const row = db.query("SELECT * FROM threads WHERE slug = ?").get(slug) as
+      | Record<string, unknown>
+      | undefined;
+    return row ? rowToThread(row) : undefined;
+  },
 };


### PR DESCRIPTION
## Summary
- Added `EventPoller` that polls each thread's Proof document for new events every 5 seconds
- Events are routed to registered agent handlers via `onEvent(handler)` callback
- `lastEventId` persisted per thread in SQLite — polling resumes correctly after restart
- Polling auto-starts for all open threads on server boot
- New threads start polling immediately; resolved threads stop polling

## Key Files
| File | Purpose |
|------|---------|
| `server/agents/event-poller.ts` | EventPoller class + singleton accessor |
| `server/agents/event-poller.test.ts` | 4 tests for poller lifecycle |
| `server/thread-store.ts` | Added `updateLastEventId`, `findAllOpen`, `findBySlug` |
| `server/index.ts` | Initialize poller on startup |
| `server/routes/threads.ts` | Start/stop polling on create/delete |

## Test plan
- [ ] `bun test` — 17 tests pass across 3 files
- [ ] `bun run typecheck` — no errors
- [ ] With docker-compose: new comment in Proof doc triggers handler within 10s
- [ ] Resolved threads stop polling

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)