### PR TITLE
feat: @mention agent trigger

### DIFF
--- a/server/agents/mention-parser.test.ts
+++ b/server/agents/mention-parser.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { parseMentions, handleMentions } from "./mention-parser.ts";
+import { AgentRegistry } from "./registry.ts";
+import type { AgentMentionEvent } from "./types.ts";
+import type { ProofEvent } from "./event-poller.ts";
+import type { Thread } from "../thread-store.ts";
+
+function makeThread(): Thread {
+  return {
+    id: "t1",
+    slug: "slug-1",
+    accessToken: "tok",
+    ownerSecret: "secret",
+    title: "Test",
+    status: "open",
+    tags: [],
+    createdBy: "agent-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    lastEventId: 0,
+    priorityCache: null,
+    priorityCachedAt: null,
+  };
+}
+
+function makeEvent(text: string, type = "comment.added"): ProofEvent {
+  return {
+    id: 1,
+    type,
+    data: { text },
+    actor: "user:someone",
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("parseMentions", () => {
+  test("extracts single mention", () => {
+    expect(parseMentions("Hey @sre-agent check this")).toEqual(["sre-agent"]);
+  });
+
+  test("extracts multiple mentions", () => {
+    expect(parseMentions("@alice and @bob please look")).toEqual([
+      "alice",
+      "bob",
+    ]);
+  });
+
+  test("deduplicates mentions", () => {
+    expect(parseMentions("@sre-agent @sre-agent hello")).toEqual(["sre-agent"]);
+  });
+
+  test("returns empty for no mentions", () => {
+    expect(parseMentions("no mentions here")).toEqual([]);
+  });
+
+  test("handles mentions with hyphens and underscores", () => {
+    expect(parseMentions("@my_agent-v2 help")).toEqual(["my_agent-v2"]);
+  });
+});
+
+describe("handleMentions", () => {
+  beforeEach(() => {
+    // Clear registry by re-registering nothing
+    // Registry doesn't have a clear method, so we just test with fresh agents
+  });
+
+  test("dispatches to registered agent", async () => {
+    const calls: AgentMentionEvent[] = [];
+    AgentRegistry.register({
+      name: "test-agent",
+      onMention(event) {
+        calls.push(event);
+      },
+    });
+
+    await handleMentions(makeThread(), makeEvent("Hey @test-agent check this"));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.mentionedAgent).toBe("test-agent");
+    expect(calls[0]!.comment.text).toBe("Hey @test-agent check this");
+    expect(calls[0]!.thread.id).toBe("t1");
+  });
+
+  test("ignores non-comment events", async () => {
+    const calls: AgentMentionEvent[] = [];
+    AgentRegistry.register({
+      name: "test-agent-2",
+      onMention(event) {
+        calls.push(event);
+      },
+    });
+
+    await handleMentions(makeThread(), makeEvent("@test-agent-2 hello", "doc.updated"));
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test("silently ignores unrecognised mentions", async () => {
+    // Should not throw
+    await handleMentions(
+      makeThread(),
+      makeEvent("@nonexistent-agent help me")
+    );
+  });
+
+  test("handles handler errors without crashing", async () => {
+    AgentRegistry.register({
+      name: "error-agent",
+      onMention() {
+        throw new Error("handler broke");
+      },
+    });
+
+    // Should not throw
+    await handleMentions(makeThread(), makeEvent("@error-agent do something"));
+  });
+});

--- a/server/agents/mention-parser.ts
+++ b/server/agents/mention-parser.ts
@@ -1,0 +1,51 @@
+import type { Thread } from "../thread-store.ts";
+import type { ProofEvent } from "./event-poller.ts";
+import { AgentRegistry } from "./registry.ts";
+import type { AgentMentionEvent } from "./types.ts";
+
+const MENTION_REGEX = /@([\w-]+)/g;
+
+/** Extract all @mentions from a string. */
+export function parseMentions(text: string): string[] {
+  const matches = [...text.matchAll(MENTION_REGEX)];
+  return [...new Set(matches.map((m) => m[1]!))];
+}
+
+/**
+ * Process a comment.add event: parse mentions and dispatch to agents.
+ * Designed to be registered as an EventPoller handler.
+ */
+export async function handleMentions(
+  thread: Thread,
+  event: ProofEvent
+): Promise<void> {
+  if (event.type !== "comment.added" && event.type !== "comment.add") return;
+
+  const text = (event.data?.text as string) ?? "";
+  if (!text) return;
+
+  const mentions = parseMentions(text);
+  if (mentions.length === 0) return;
+
+  const mentionEvent: AgentMentionEvent = {
+    thread,
+    comment: {
+      text,
+      quote: event.data?.quote as string | undefined,
+      actor: event.actor,
+      createdAt: event.createdAt,
+    },
+    mentionedAgent: "", // set per agent below
+  };
+
+  for (const name of mentions) {
+    const agent = AgentRegistry.get(name);
+    if (!agent?.onMention) continue;
+
+    try {
+      await agent.onMention({ ...mentionEvent, mentionedAgent: name });
+    } catch (err) {
+      console.error(`Mention handler error for @${name}:`, err);
+    }
+  }
+}

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -1,0 +1,21 @@
+import type { AgentHandler } from "./types.ts";
+
+const agents = new Map<string, AgentHandler>();
+
+export const AgentRegistry = {
+  register(agent: AgentHandler): void {
+    agents.set(agent.name, agent);
+  },
+
+  get(name: string): AgentHandler | undefined {
+    return agents.get(name);
+  },
+
+  all(): AgentHandler[] {
+    return [...agents.values()];
+  },
+
+  has(name: string): boolean {
+    return agents.has(name);
+  },
+};

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -1,0 +1,17 @@
+import type { Thread } from "../thread-store.ts";
+
+export interface AgentMentionEvent {
+  thread: Thread;
+  comment: {
+    text: string;
+    quote?: string;
+    actor: string;
+    createdAt: string;
+  };
+  mentionedAgent: string;
+}
+
+export interface AgentHandler {
+  name: string;
+  onMention?(event: AgentMentionEvent): void | Promise<void>;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { ProofClient } from "./proof-client.ts";
 import { initEventPoller, getEventPoller } from "./agents/event-poller.ts";
+import { handleMentions } from "./agents/mention-parser.ts";
 
 // Initialize DB (runs migrations on import)
 import "./db/index.ts";
@@ -9,7 +10,8 @@ const app = express();
 const PORT = Number.parseInt(process.env.PORT ?? "3000", 10);
 const proofClient = new ProofClient();
 
-initEventPoller(proofClient);
+const poller = initEventPoller(proofClient);
+poller.onEvent(handleMentions);
 
 // Import routes after poller is initialized
 const { default: threadRoutes } = await import("./routes/threads.ts");


### PR DESCRIPTION
## Summary
- Added `MentionParser` that scans `comment.add`/`comment.added` events for `@agent-name` patterns
- Added `AgentRegistry` for registering and looking up agent handlers by name
- Added shared `AgentHandler` and `AgentMentionEvent` types for the agent system
- Wired mention handler into `EventPoller` on server startup
- Unrecognised mentions silently ignored; handler errors caught and logged

## Key Files
| File | Purpose |
|------|---------|
| `server/agents/mention-parser.ts` | Parse @mentions and dispatch to agents |
| `server/agents/registry.ts` | Agent registration and lookup |
| `server/agents/types.ts` | Shared agent types |
| `server/agents/mention-parser.test.ts` | 9 tests for parsing and dispatch |

## Test plan
- [ ] `bun test` — 26 tests pass across 4 files
- [ ] `bun run typecheck` — no errors
- [ ] `@agent-name` in a Proof comment dispatches to registered agent
- [ ] Unrecognised mentions don't crash

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)