### PR TITLE
feat: scheduled scan agent trigger

### DIFF
--- a/server/agents/scheduled-scanner.test.ts
+++ b/server/agents/scheduled-scanner.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "bun:test";
+import { ScheduledScanner } from "./scheduled-scanner.ts";
+
+describe("ScheduledScanner", () => {
+  describe("parseScanResponse", () => {
+    test("parses valid JSON array", () => {
+      const text = `[{"threadId":"t1","reason":"Stale for 2 hours"}]`;
+      const result = ScheduledScanner.parseScanResponse(text);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.threadId).toBe("t1");
+      expect(result[0]!.reason).toBe("Stale for 2 hours");
+    });
+
+    test("extracts JSON from surrounding text", () => {
+      const text = `Here are the flagged threads:\n[{"threadId":"t2","reason":"Escalated"}]\nDone.`;
+      const result = ScheduledScanner.parseScanResponse(text);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.threadId).toBe("t2");
+    });
+
+    test("returns empty array for empty response", () => {
+      expect(ScheduledScanner.parseScanResponse("[]")).toEqual([]);
+    });
+
+    test("returns empty array for no JSON", () => {
+      expect(ScheduledScanner.parseScanResponse("no threads need attention")).toEqual([]);
+    });
+
+    test("returns empty array for invalid JSON", () => {
+      expect(ScheduledScanner.parseScanResponse("[invalid json}")).toEqual([]);
+    });
+
+    test("handles multiple flagged threads", () => {
+      const text = `[{"threadId":"a","reason":"Stale"},{"threadId":"b","reason":"Escalated"},{"threadId":"c","reason":"Urgent"}]`;
+      const result = ScheduledScanner.parseScanResponse(text);
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe("lifecycle", () => {
+    test("start and stop", () => {
+      ScheduledScanner.start();
+      expect(ScheduledScanner.isRunning).toBe(true);
+
+      ScheduledScanner.stop();
+      expect(ScheduledScanner.isRunning).toBe(false);
+    });
+
+    test("start is idempotent", () => {
+      ScheduledScanner.start();
+      ScheduledScanner.start(); // no-op
+      expect(ScheduledScanner.isRunning).toBe(true);
+
+      ScheduledScanner.stop();
+    });
+  });
+});

--- a/server/agents/scheduled-scanner.ts
+++ b/server/agents/scheduled-scanner.ts
@@ -1,0 +1,130 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { ThreadStore, type Thread } from "../thread-store.ts";
+import { AgentRegistry } from "./registry.ts";
+
+const SCAN_INTERVAL_MS = Number.parseInt(
+  process.env.SCAN_INTERVAL_MS ?? "600000",
+  10
+);
+
+const anthropic = new Anthropic();
+
+interface ScanResult {
+  threadId: string;
+  reason: string;
+}
+
+function buildScanPrompt(threads: Thread[]): string {
+  const threadList = threads
+    .map(
+      (t) =>
+        `- ID: ${t.id} | Title: "${t.title}" | Status: ${t.status} | Tags: [${t.tags.join(", ")}] | Updated: ${t.updatedAt} | Created: ${t.createdAt}`
+    )
+    .join("\n");
+
+  return `You are a thread triage assistant. Review these open threads and identify which ones need proactive attention.
+
+Flag threads that are:
+- Stale (no activity in >30 minutes)
+- Escalating (status is 'escalated' or tags suggest urgency)
+- Unresolved for too long
+
+Current time: ${new Date().toISOString()}
+
+Threads:
+${threadList}
+
+Respond with ONLY a JSON array of threads needing attention. Each element must have:
+- "threadId": the thread ID
+- "reason": brief explanation (max 15 words)
+
+If no threads need attention, respond with an empty array: []`;
+}
+
+function parseScanResponse(text: string): ScanResult[] {
+  const match = text.match(/\[[\s\S]*\]/);
+  if (!match) return [];
+  try {
+    return JSON.parse(match[0]) as ScanResult[];
+  } catch {
+    return [];
+  }
+}
+
+async function runScan(): Promise<void> {
+  const threads = ThreadStore.findAllOpen();
+  if (threads.length === 0) return;
+
+  const prompt = buildScanPrompt(threads);
+
+  let results: ScanResult[];
+  try {
+    const response = await anthropic.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 512,
+      messages: [{ role: "user", content: prompt }],
+    });
+
+    const text =
+      response.content[0]?.type === "text" ? response.content[0].text : "";
+    results = parseScanResponse(text);
+  } catch (err) {
+    console.error("Scheduled scan LLM call failed:", err);
+    return;
+  }
+
+  if (results.length === 0) return;
+
+  const threadMap = new Map(threads.map((t) => [t.id, t]));
+  const agents = AgentRegistry.all();
+
+  for (const result of results) {
+    const thread = threadMap.get(result.threadId);
+    if (!thread) continue;
+
+    for (const agent of agents) {
+      if (!agent.onScan) continue;
+      try {
+        await agent.onScan({ thread, reason: result.reason });
+      } catch (err) {
+        console.error(
+          `Scan handler error for agent ${agent.name} on thread ${thread.id}:`,
+          err
+        );
+      }
+    }
+  }
+
+  console.log(
+    `Scheduled scan: flagged ${results.length} thread(s) for attention`
+  );
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+export const ScheduledScanner = {
+  start(): void {
+    if (timer) return;
+    console.log(
+      `ScheduledScanner: starting with interval ${SCAN_INTERVAL_MS}ms`
+    );
+    // Run first scan after a short delay to let the system settle
+    setTimeout(runScan, 5_000);
+    timer = setInterval(runScan, SCAN_INTERVAL_MS);
+  },
+
+  stop(): void {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  },
+
+  /** Expose for testing. */
+  runScan,
+  parseScanResponse,
+
+  get isRunning(): boolean {
+    return timer !== null;
+  },
+};

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -11,7 +11,13 @@ export interface AgentMentionEvent {
   mentionedAgent: string;
 }
 
+export interface AgentScanEvent {
+  thread: Thread;
+  reason: string;
+}
+
 export interface AgentHandler {
   name: string;
   onMention?(event: AgentMentionEvent): void | Promise<void>;
+  onScan?(event: AgentScanEvent): void | Promise<void>;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { ProofClient } from "./proof-client.ts";
 import { initEventPoller, getEventPoller } from "./agents/event-poller.ts";
 import { handleMentions } from "./agents/mention-parser.ts";
+import { ScheduledScanner } from "./agents/scheduled-scanner.ts";
 
 // Initialize DB (runs migrations on import)
 import "./db/index.ts";
@@ -33,4 +34,5 @@ app.use("/api/threads", threadRoutes);
 app.listen(PORT, () => {
   console.log(`proof-queue listening on http://localhost:${PORT}`);
   getEventPoller().startAll();
+  ScheduledScanner.start();
 });


### PR DESCRIPTION
## Summary
- Added `ScheduledScanner` that runs every 10 minutes (configurable via `SCAN_INTERVAL_MS` env)
- Calls Claude to identify open threads needing proactive attention (stale >30min, escalating, unresolved)
- Dispatches `AgentScanEvent` to all registered agents with `onScan` handlers
- Skips scan when no open threads exist
- Added `onScan` to the `AgentHandler` interface

## Key Files
| File | Purpose |
|------|---------|
| `server/agents/scheduled-scanner.ts` | Cron-based scan + LLM triage |
| `server/agents/scheduled-scanner.test.ts` | 8 tests for parsing + lifecycle |
| `server/agents/types.ts` | Added `AgentScanEvent` + `onScan` |

## Test plan
- [ ] `bun test` — 34 tests pass across 5 files
- [ ] `bun run typecheck` — no errors
- [ ] With `ANTHROPIC_API_KEY`: scanner flags stale threads and dispatches to agents
- [ ] `SCAN_INTERVAL_MS=30000` overrides default 10min interval

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)