### PR TITLE
feat: web UI thread view with embedded Proof editor

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-router-dom": "^7.13.1",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -203,6 +204,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
@@ -365,6 +368,10 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-router": ["react-router@7.13.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA=="],
+
+    "react-router-dom": ["react-router-dom@7.13.1", "", { "dependencies": { "react-router": "7.13.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw=="],
+
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "rolldown": ["rolldown@1.0.0-rc.9", "", { "dependencies": { "@oxc-project/types": "=0.115.0", "@rolldown/pluginutils": "1.0.0-rc.9" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-x64": "1.0.0-rc.9", "@rolldown/binding-freebsd-x64": "1.0.0-rc.9", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q=="],
@@ -372,6 +379,8 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,16 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { QueuePage } from './pages/QueuePage'
+import { ThreadPage } from './pages/ThreadPage'
 
 function App() {
-  return <QueuePage />
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<QueuePage />} />
+        <Route path="/threads/:id" element={<ThreadPage />} />
+      </Routes>
+    </BrowserRouter>
+  )
 }
 
 export default App

--- a/web/src/components/InviteForm.tsx
+++ b/web/src/components/InviteForm.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+
+interface Props {
+  threadId: string
+  onInvited: () => void
+}
+
+export function InviteForm({ threadId, onInvited }: Props) {
+  const [identity, setIdentity] = useState('')
+  const [reason, setReason] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!identity || !reason) return
+
+    setSubmitting(true)
+    try {
+      await fetch(`/api/threads/${threadId}/invite`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identity, reason }),
+      })
+      setIdentity('')
+      setReason('')
+      onInvited()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form className="invite-form" onSubmit={handleSubmit}>
+      <h3>Invite</h3>
+      <input
+        placeholder="e.g. human:alice or ai:sre-agent"
+        value={identity}
+        onChange={(e) => setIdentity(e.target.value)}
+        required
+      />
+      <input
+        placeholder="Reason"
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        required
+      />
+      <button type="submit" disabled={submitting}>
+        {submitting ? 'Inviting...' : 'Invite'}
+      </button>
+    </form>
+  )
+}

--- a/web/src/components/ParticipantList.tsx
+++ b/web/src/components/ParticipantList.tsx
@@ -1,0 +1,29 @@
+interface Participant {
+  id: string
+  agentId: string
+  role: string
+  joinedAt: string
+}
+
+export function ParticipantList({ participants }: { participants: Participant[] }) {
+  if (participants.length === 0) {
+    return <div className="participants-empty">No participants yet</div>
+  }
+
+  return (
+    <div className="participant-list">
+      <h3>Participants</h3>
+      <ul>
+        {participants.map((p) => (
+          <li key={p.id} className="participant-item">
+            <span className={`participant-icon ${p.role === 'agent' ? 'is-agent' : ''}`}>
+              {p.role === 'agent' ? '🤖' : '👤'}
+            </span>
+            <span className="participant-name">{p.agentId}</span>
+            <span className="participant-role">{p.role}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/web/src/components/StatusDropdown.tsx
+++ b/web/src/components/StatusDropdown.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+
+const STATUSES = ['open', 'in_progress', 'resolved', 'escalated'] as const
+
+interface Props {
+  threadId: string
+  currentStatus: string
+  onChanged: (status: string) => void
+}
+
+export function StatusDropdown({ threadId, currentStatus, onChanged }: Props) {
+  const [updating, setUpdating] = useState(false)
+
+  const handleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const status = e.target.value
+    setUpdating(true)
+    try {
+      const res = await fetch(`/api/threads/${threadId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      })
+      if (res.ok) onChanged(status)
+    } finally {
+      setUpdating(false)
+    }
+  }
+
+  return (
+    <div className="status-dropdown">
+      <h3>Status</h3>
+      <select value={currentStatus} onChange={handleChange} disabled={updating}>
+        {STATUSES.map((s) => (
+          <option key={s} value={s}>
+            {s.replace('_', ' ')}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/web/src/components/ThreadCard.tsx
+++ b/web/src/components/ThreadCard.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import type { Thread } from '../hooks/useThreads'
 
 const STATUS_COLORS: Record<string, string> = {
@@ -20,6 +21,7 @@ export function ThreadCard({ thread }: { thread: Thread }) {
   const statusColor = STATUS_COLORS[thread.status] ?? '#6b7280'
 
   return (
+    <Link to={`/threads/${thread.id}`} className="thread-card-link">
     <div className="thread-card">
       <div className="thread-header">
         <h3 className="thread-title">{thread.title}</h3>
@@ -48,5 +50,6 @@ export function ThreadCard({ thread }: { thread: Thread }) {
         </span>
       </div>
     </div>
+    </Link>
   )
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -240,3 +240,165 @@ body { margin: 0; }
 .error {
   color: var(--red);
 }
+
+/* Thread card link */
+.thread-card-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+/* Thread Detail Page */
+.thread-page {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+}
+
+.thread-page-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+  flex-shrink: 0;
+}
+
+.thread-page-header h1 {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.thread-page-tags {
+  display: flex;
+  gap: 4px;
+}
+
+.back-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.back-link:hover {
+  color: var(--accent-hover);
+}
+
+/* Thread Layout */
+.thread-layout {
+  display: flex;
+  gap: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
+.thread-editor {
+  flex: 1;
+  min-width: 0;
+}
+
+.proof-iframe {
+  width: 100%;
+  height: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: white;
+}
+
+/* Sidebar */
+.thread-sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+}
+
+.thread-sidebar h3 {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 8px;
+}
+
+/* Participants */
+.participant-list ul {
+  list-style: none;
+  padding: 0;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.participant-name {
+  flex: 1;
+  color: var(--text);
+}
+
+.participant-role {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.participants-empty {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+/* Invite Form */
+.invite-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.invite-form input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.invite-form input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.invite-form button {
+  background: var(--accent);
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+/* Status Dropdown */
+.status-dropdown select {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.status-dropdown select:focus {
+  outline: none;
+  border-color: var(--accent);
+}

--- a/web/src/pages/ThreadPage.tsx
+++ b/web/src/pages/ThreadPage.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { ParticipantList } from '../components/ParticipantList'
+import { InviteForm } from '../components/InviteForm'
+import { StatusDropdown } from '../components/StatusDropdown'
+
+interface ThreadDetail {
+  id: string
+  slug: string
+  accessToken: string
+  title: string
+  status: string
+  tags: string[]
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+  participants: Array<{
+    id: string
+    agentId: string
+    role: string
+    joinedAt: string
+  }>
+}
+
+const PROOF_SDK_URL = 'http://localhost:4000'
+
+export function ThreadPage() {
+  const { id } = useParams<{ id: string }>()
+  const [thread, setThread] = useState<ThreadDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchThread = useCallback(async () => {
+    if (!id) return
+    try {
+      const res = await fetch(`/api/threads/${id}`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setThread(data)
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => {
+    fetchThread()
+  }, [fetchThread])
+
+  if (loading) return <div className="loading">Loading thread...</div>
+  if (error) return <div className="error">Error: {error}</div>
+  if (!thread) return <div className="error">Thread not found</div>
+
+  const editorUrl = `${PROOF_SDK_URL}/d/${thread.slug}?token=${thread.accessToken}`
+
+  return (
+    <div className="thread-page">
+      <div className="thread-page-header">
+        <Link to="/" className="back-link">← Queue</Link>
+        <h1>{thread.title}</h1>
+        <div className="thread-page-tags">
+          {thread.tags.map((tag) => (
+            <span key={tag} className="tag">{tag}</span>
+          ))}
+        </div>
+      </div>
+
+      <div className="thread-layout">
+        <div className="thread-editor">
+          <iframe
+            src={editorUrl}
+            title="Proof Editor"
+            className="proof-iframe"
+          />
+        </div>
+
+        <aside className="thread-sidebar">
+          <StatusDropdown
+            threadId={thread.id}
+            currentStatus={thread.status}
+            onChanged={(status) => setThread((t) => t ? { ...t, status } : t)}
+          />
+
+          <ParticipantList participants={thread.participants} />
+
+          <InviteForm threadId={thread.id} onInvited={fetchThread} />
+        </aside>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Added `ThreadPage` showing live Proof editor in an iframe alongside a sidebar
- Sidebar has: participants list, invite form (`POST /api/threads/:id/invite`), status dropdown (`PATCH /api/threads/:id`)
- Added react-router-dom with routes: `/` (queue) and `/threads/:id` (detail)
- ThreadCard now links to the detail page
- Full dark-theme CSS for thread layout, sidebar, and all new components

## Key Files
| File | Purpose |
|------|---------|
| `web/src/pages/ThreadPage.tsx` | Thread detail with embedded Proof editor |
| `web/src/components/ParticipantList.tsx` | Participants sidebar |
| `web/src/components/InviteForm.tsx` | Invite humans/agents |
| `web/src/components/StatusDropdown.tsx` | Thread status control |
| `web/src/App.tsx` | Router setup |

## Test plan
- [ ] `bun test` — 50 tests pass
- [ ] `cd web && npx tsc --noEmit && npx vite build` — builds clean
- [ ] Navigate from queue to thread detail page
- [ ] Proof editor loads in iframe
- [ ] Invite form adds participant and posts comment in Proof doc
- [ ] Status change reflected in queue view via SSE

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)