### PR TITLE
feat: pq CLI

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,34 @@
+# dependencies (bun install)
+node_modules
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -1,0 +1,56 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "cli",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "open": "^11.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pq",
+  "module": "src/main.ts",
+  "type": "module",
+  "bin": {
+    "pq": "src/main.ts"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "commander": "^14.0.3",
+    "open": "^11.0.0"
+  }
+}

--- a/cli/src/api-client.ts
+++ b/cli/src/api-client.ts
@@ -1,0 +1,49 @@
+import { getConfig } from "./config.ts";
+
+function baseUrl(): string {
+  return getConfig().serverUrl;
+}
+
+async function request(path: string, options?: RequestInit) {
+  const res = await fetch(`${baseUrl()}${path}`, {
+    ...options,
+    headers: { "Content-Type": "application/json", ...options?.headers },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`HTTP ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+export const api = {
+  listThreads(profile?: string) {
+    const params = profile ? `?profile=${profile}` : "";
+    return request(`/api/threads${params}`);
+  },
+
+  getThread(id: string) {
+    return request(`/api/threads/${id}`);
+  },
+
+  createThread(title: string, tags?: string[], createdBy = "cli-user") {
+    return request("/api/threads", {
+      method: "POST",
+      body: JSON.stringify({ title, tags, createdBy }),
+    });
+  },
+
+  updateStatus(id: string, status: string) {
+    return request(`/api/threads/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ status }),
+    });
+  },
+
+  invite(id: string, identity: string, reason: string) {
+    return request(`/api/threads/${id}/invite`, {
+      method: "POST",
+      body: JSON.stringify({ identity, reason, invitedBy: "cli-user" }),
+    });
+  },
+};

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { api } from "../api-client.ts";
+
+export const createCmd = new Command("create")
+  .description("Create a new thread")
+  .argument("<title>", "Thread title")
+  .option("-t, --tags <tags>", "Comma-separated tags")
+  .option("-u, --user <user>", "Created by", "cli-user")
+  .action(async (title, opts) => {
+    const tags = opts.tags?.split(",").map((t: string) => t.trim()).filter(Boolean);
+    const thread = await api.createThread(title, tags, opts.user);
+    console.log(`Thread created: ${thread.id}`);
+    console.log(`  Title: ${thread.title}`);
+    console.log(`  Slug:  ${thread.slug}`);
+    if (thread.proofUrl) {
+      console.log(`  Proof: http://localhost:4000${thread.proofUrl}`);
+    }
+  });

--- a/cli/src/commands/invite.ts
+++ b/cli/src/commands/invite.ts
@@ -1,0 +1,12 @@
+import { Command } from "commander";
+import { api } from "../api-client.ts";
+
+export const inviteCmd = new Command("invite")
+  .description("Invite human or agent to a thread")
+  .argument("<id>", "Thread ID")
+  .argument("<identity>", "Identity (e.g. human:alice, ai:sre-agent)")
+  .option("-r, --reason <reason>", "Reason for invite", "Invited via CLI")
+  .action(async (id, identity, opts) => {
+    const result = await api.invite(id, identity, opts.reason);
+    console.log(`Invited ${result.identity} to thread ${result.threadId} as ${result.role}`);
+  });

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -1,0 +1,35 @@
+import { Command } from "commander";
+import { api } from "../api-client.ts";
+
+export const listCmd = new Command("list")
+  .description("Show ranked queue as table")
+  .option("-p, --profile <profile>", "Rank by profile (sre, quant, developer, pm, user)")
+  .action(async (opts) => {
+    const threads = await api.listThreads(opts.profile);
+
+    if (threads.length === 0) {
+      console.log("No threads found.");
+      return;
+    }
+
+    // Print table
+    const header = ["ID", "Title", "Status", "Tags", "Score", "Reason"].map(
+      (h) => h.padEnd(h === "Title" ? 30 : h === "Reason" ? 30 : h === "ID" ? 36 : 12)
+    );
+    console.log(header.join(" "));
+    console.log("-".repeat(header.join(" ").length));
+
+    for (const t of threads) {
+      const score = t.priority?.score ?? "-";
+      const reason = t.priority?.reason ?? "";
+      const row = [
+        (t.id as string).padEnd(36),
+        (t.title as string).slice(0, 28).padEnd(30),
+        (t.status as string).padEnd(12),
+        ((t.tags as string[]).join(",") || "-").slice(0, 10).padEnd(12),
+        String(score).padEnd(12),
+        (reason as string).slice(0, 28).padEnd(30),
+      ];
+      console.log(row.join(" "));
+    }
+  });

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -1,0 +1,13 @@
+import { Command } from "commander";
+import open from "open";
+import { api } from "../api-client.ts";
+
+export const openCmd = new Command("open")
+  .description("Open Proof doc in browser")
+  .argument("<id>", "Thread ID")
+  .action(async (id) => {
+    const thread = await api.getThread(id);
+    const url = `http://localhost:4000/d/${thread.slug}?token=${thread.accessToken}`;
+    console.log(`Opening: ${url}`);
+    await open(url);
+  });

--- a/cli/src/commands/show.ts
+++ b/cli/src/commands/show.ts
@@ -1,0 +1,24 @@
+import { Command } from "commander";
+import { api } from "../api-client.ts";
+
+export const showCmd = new Command("show")
+  .description("Show thread detail")
+  .argument("<id>", "Thread ID")
+  .action(async (id) => {
+    const thread = await api.getThread(id);
+    console.log(`Title:       ${thread.title}`);
+    console.log(`ID:          ${thread.id}`);
+    console.log(`Slug:        ${thread.slug}`);
+    console.log(`Status:      ${thread.status}`);
+    console.log(`Tags:        ${(thread.tags as string[]).join(", ") || "none"}`);
+    console.log(`Created by:  ${thread.createdBy}`);
+    console.log(`Created at:  ${thread.createdAt}`);
+    console.log(`Updated at:  ${thread.updatedAt}`);
+
+    if (thread.participants?.length) {
+      console.log(`\nParticipants:`);
+      for (const p of thread.participants) {
+        console.log(`  ${p.agentId} (${p.role})`);
+      }
+    }
+  });

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import { api } from "../api-client.ts";
+
+export const statusCmd = new Command("status")
+  .description("Update thread status")
+  .argument("<id>", "Thread ID")
+  .argument("<status>", "New status (open, in_progress, resolved, escalated)")
+  .action(async (id, status) => {
+    const thread = await api.updateStatus(id, status);
+    console.log(`Thread ${thread.id} status updated to: ${thread.status}`);
+  });

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,0 +1,34 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const CONFIG_DIR = join(homedir(), ".pq");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+interface Config {
+  serverUrl: string;
+}
+
+const DEFAULT_CONFIG: Config = {
+  serverUrl: "http://localhost:3000",
+};
+
+export function getConfig(): Config {
+  try {
+    if (existsSync(CONFIG_FILE)) {
+      const raw = readFileSync(CONFIG_FILE, "utf-8");
+      return { ...DEFAULT_CONFIG, ...JSON.parse(raw) };
+    }
+  } catch {
+    // fall through to default
+  }
+  return DEFAULT_CONFIG;
+}
+
+export function saveConfig(config: Partial<Config>): void {
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true });
+  }
+  const current = getConfig();
+  writeFileSync(CONFIG_FILE, JSON.stringify({ ...current, ...config }, null, 2));
+}

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env bun
+import { Command } from "commander";
+import { listCmd } from "./commands/list.ts";
+import { createCmd } from "./commands/create.ts";
+import { showCmd } from "./commands/show.ts";
+import { openCmd } from "./commands/open.ts";
+import { statusCmd } from "./commands/status.ts";
+import { inviteCmd } from "./commands/invite.ts";
+
+const program = new Command()
+  .name("pq")
+  .description("proof-queue CLI — terminal access to the work queue")
+  .version("0.1.0");
+
+program.addCommand(listCmd);
+program.addCommand(createCmd);
+program.addCommand(showCmd);
+program.addCommand(openCmd);
+program.addCommand(statusCmd);
+program.addCommand(inviteCmd);
+
+program.parse();

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
## Summary
- Added `pq` CLI in `cli/` using commander for terminal-native queue access
- Config at `~/.pq/config.json` with `serverUrl` (default `http://localhost:3000`)
- `ApiClient` wraps queue server HTTP API

## Commands
| Command | Description |
|---------|-------------|
| `pq list [--profile sre]` | Show ranked queue as table |
| `pq create <title> [--tags a,b]` | Create thread, prints URL |
| `pq show <id>` | Thread detail + participants |
| `pq open <id>` | Open Proof doc in browser |
| `pq status <id> <status>` | Update thread status |
| `pq invite <id> <identity>` | Invite human or agent |

## Key Files
| File | Purpose |
|------|---------|
| `cli/src/main.ts` | CLI entry point |
| `cli/src/api-client.ts` | HTTP API wrapper |
| `cli/src/config.ts` | Config file management |
| `cli/src/commands/*.ts` | Individual command modules |

## Test plan
- [ ] `cd cli && bun run src/main.ts --help` shows all commands
- [ ] `pq list` prints queue table (with server running)
- [ ] `pq create "Auth down" --tags incident,sre` creates thread
- [ ] `pq open <id>` opens browser
- [ ] `pq invite <id> ai:sre-agent` triggers invitation

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)