### PR TITLE
feat: Slack bot integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "proof-queue",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
+        "@slack/bolt": "^4.6.0",
         "express": "^5.2.1",
         "uuid": "^13.0.0",
       },
@@ -25,6 +26,18 @@
 
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
+    "@slack/bolt": ["@slack/bolt@4.6.0", "", { "dependencies": { "@slack/logger": "^4.0.0", "@slack/oauth": "^3.0.4", "@slack/socket-mode": "^2.0.5", "@slack/types": "^2.18.0", "@slack/web-api": "^7.12.0", "axios": "^1.12.0", "express": "^5.0.0", "path-to-regexp": "^8.1.0", "raw-body": "^3", "tsscmp": "^1.0.6" }, "peerDependencies": { "@types/express": "^5.0.0" } }, "sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ=="],
+
+    "@slack/logger": ["@slack/logger@4.0.1", "", { "dependencies": { "@types/node": ">=18" } }, "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ=="],
+
+    "@slack/oauth": ["@slack/oauth@3.0.5", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/jsonwebtoken": "^9", "@types/node": ">=18", "jsonwebtoken": "^9" } }, "sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A=="],
+
+    "@slack/socket-mode": ["@slack/socket-mode@2.0.6", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/node": ">=18", "@types/ws": "^8", "eventemitter3": "^5", "ws": "^8" } }, "sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ=="],
+
+    "@slack/types": ["@slack/types@2.20.1", "", {}, "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A=="],
+
+    "@slack/web-api": ["@slack/web-api@7.15.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.20.1", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.13.5", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw=="],
+
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
     "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
@@ -37,11 +50,17 @@
 
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
+    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/qs": ["@types/qs@6.15.0", "", {}, "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow=="],
 
     "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
 
@@ -49,9 +68,17 @@
 
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
@@ -60,6 +87,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -71,9 +100,13 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -85,13 +118,21 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -107,6 +148,8 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
@@ -117,9 +160,33 @@
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
+
+    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
+
+    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
+
+    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
+
+    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
+
+    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
+
+    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -141,11 +208,21 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
@@ -153,9 +230,15 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
@@ -177,6 +260,8 @@
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
+    "tsscmp": ["tsscmp@1.0.6", "", {}, "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="],
+
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -190,5 +275,13 @@
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
+    "@slack/bolt": "^4.6.0",
     "express": "^5.2.1",
     "uuid": "^13.0.0"
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import { ScheduledScanner } from "./agents/scheduled-scanner.ts";
 import { AgentRegistry } from "./agents/registry.ts";
 import { TriageAgent } from "./agents/triage-agent.ts";
 import { SreAgent } from "./agents/sre-agent.ts";
+import { initSlack } from "./slack/slack-app.ts";
 
 // Initialize DB (runs migrations on import)
 import "./db/index.ts";
@@ -39,6 +40,9 @@ app.get("/health", async (_req, res) => {
 
 app.use("/api/threads", threadRoutes);
 app.use("/api/threads/:id/invite", inviteRoutes);
+
+// Initialize Slack (no-op if SLACK_BOT_TOKEN not set)
+initSlack(app);
 
 app.listen(PORT, () => {
   console.log(`proof-queue listening on http://localhost:${PORT}`);

--- a/server/routes/threads.ts
+++ b/server/routes/threads.ts
@@ -6,6 +6,7 @@ import { PROFILES, type ProfileName } from "../ranking/profiles.ts";
 import { getEventPoller } from "../agents/event-poller.ts";
 import { AgentRegistry } from "../agents/registry.ts";
 import { addClient, broadcast } from "../sse.ts";
+import { notifyThreadCreated } from "../slack/slack-app.ts";
 
 const router = Router();
 const proofClient = new ProofClient();
@@ -68,6 +69,7 @@ router.post("/", async (req, res) => {
   }
 
   broadcast("thread:created", thread);
+  notifyThreadCreated(thread).catch(() => {});
 
   res.status(201).json({
     ...thread,

--- a/server/slack/commands.ts
+++ b/server/slack/commands.ts
@@ -1,0 +1,101 @@
+import type { App } from "@slack/bolt";
+import { ThreadStore } from "../thread-store.ts";
+import { ProofClient } from "../proof-client.ts";
+import { rankThreads } from "../ranking/ranking-service.ts";
+import { PROFILES, type ProfileName } from "../ranking/profiles.ts";
+import { queueTable, threadCard } from "./formatters.ts";
+
+const proofClient = new ProofClient();
+
+export function registerCommands(app: App): void {
+  app.command("/pq", async ({ command, ack, respond }) => {
+    await ack();
+
+    const args = command.text.trim().split(/\s+/);
+    const subcommand = args[0] ?? "list";
+
+    switch (subcommand) {
+      case "list": {
+        const profile = args[1];
+        const threads = ThreadStore.findAll();
+
+        if (profile && profile in PROFILES) {
+          try {
+            const ranked = await rankThreads(threads, profile as ProfileName);
+            const rankMap = new Map(ranked.map((r) => [r.threadId, r]));
+            const enriched = threads.map((t) => {
+              const rank = rankMap.get(t.id);
+              return {
+                ...t,
+                priority: rank
+                  ? { score: rank.score, reason: rank.reason }
+                  : undefined,
+              };
+            }).sort((a, b) => (b.priority?.score ?? 0) - (a.priority?.score ?? 0));
+            await respond({ text: queueTable(enriched), response_type: "ephemeral" });
+          } catch {
+            await respond({ text: queueTable(threads), response_type: "ephemeral" });
+          }
+        } else {
+          await respond({ text: queueTable(threads), response_type: "ephemeral" });
+        }
+        break;
+      }
+
+      case "open": {
+        const id = args[1];
+        if (!id) {
+          await respond({ text: "Usage: `/pq open <id>`", response_type: "ephemeral" });
+          return;
+        }
+        const thread = ThreadStore.findById(id);
+        if (!thread) {
+          await respond({ text: `Thread \`${id}\` not found.`, response_type: "ephemeral" });
+          return;
+        }
+        const url = `http://localhost:4000/d/${thread.slug}?token=${thread.accessToken}`;
+        await respond({ text: `<${url}|Open in Proof>`, response_type: "ephemeral" });
+        break;
+      }
+
+      case "create": {
+        const title = args.slice(1).join(" ");
+        if (!title) {
+          await respond({ text: "Usage: `/pq create <title>`", response_type: "ephemeral" });
+          return;
+        }
+
+        try {
+          const doc = await proofClient.createDocument({ title });
+          const thread = ThreadStore.create({
+            slug: doc.slug,
+            accessToken: doc.accessToken,
+            ownerSecret: doc.ownerSecret,
+            title,
+            createdBy: `slack:${command.user_name}`,
+          });
+          ThreadStore.addParticipant(thread.id, command.user_name, "owner");
+
+          const channel = process.env.SLACK_CHANNEL ?? "#incidents";
+          await respond({
+            text: `Thread created: *${thread.title}*`,
+            response_type: "in_channel",
+            blocks: threadCard(thread),
+          });
+        } catch (err) {
+          await respond({
+            text: `Failed to create thread: ${err}`,
+            response_type: "ephemeral",
+          });
+        }
+        break;
+      }
+
+      default:
+        await respond({
+          text: "Commands: `/pq list [profile]`, `/pq open <id>`, `/pq create <title>`",
+          response_type: "ephemeral",
+        });
+    }
+  });
+}

--- a/server/slack/formatters.ts
+++ b/server/slack/formatters.ts
@@ -1,0 +1,65 @@
+import type { Thread } from "../thread-store.ts";
+
+const STATUS_EMOJI: Record<string, string> = {
+  open: ":large_blue_circle:",
+  in_progress: ":large_yellow_circle:",
+  resolved: ":white_check_mark:",
+  escalated: ":red_circle:",
+};
+
+export function threadCard(thread: Thread & { priority?: { score: number; reason: string } }) {
+  const emoji = STATUS_EMOJI[thread.status] ?? ":grey_question:";
+  const tags = thread.tags.length > 0 ? thread.tags.map((t) => `\`${t}\``).join(" ") : "none";
+  const proofUrl = `http://localhost:4000/d/${thread.slug}?token=${thread.accessToken}`;
+  const score = thread.priority?.score ?? "–";
+  const reason = thread.priority?.reason ?? "";
+
+  return [
+    {
+      type: "header" as const,
+      text: { type: "plain_text" as const, text: thread.title, emoji: true },
+    },
+    {
+      type: "section" as const,
+      fields: [
+        { type: "mrkdwn" as const, text: `*Status:* ${emoji} ${thread.status}` },
+        { type: "mrkdwn" as const, text: `*Priority:* ${score}` },
+        { type: "mrkdwn" as const, text: `*Tags:* ${tags}` },
+        { type: "mrkdwn" as const, text: `*Created by:* ${thread.createdBy}` },
+      ],
+    },
+    ...(reason
+      ? [
+          {
+            type: "context" as const,
+            elements: [{ type: "mrkdwn" as const, text: `_${reason}_` }],
+          },
+        ]
+      : []),
+    {
+      type: "actions" as const,
+      elements: [
+        {
+          type: "button" as const,
+          text: { type: "plain_text" as const, text: "Open in Proof" },
+          url: proofUrl,
+          action_id: "open_proof",
+        },
+      ],
+    },
+  ];
+}
+
+export function queueTable(
+  threads: Array<Thread & { priority?: { score: number; reason: string } }>
+): string {
+  if (threads.length === 0) return "No threads in the queue.";
+
+  const lines = threads.map((t, i) => {
+    const score = t.priority?.score ?? "–";
+    const status = t.status.replace("_", " ");
+    return `${i + 1}. *${t.title}* — ${status} (score: ${score})`;
+  });
+
+  return lines.join("\n");
+}

--- a/server/slack/slack-app.ts
+++ b/server/slack/slack-app.ts
@@ -1,0 +1,109 @@
+import { App, ExpressReceiver } from "@slack/bolt";
+import type { Express } from "express";
+import { ProofClient } from "../proof-client.ts";
+import { ThreadStore } from "../thread-store.ts";
+import { threadCard } from "./formatters.ts";
+import { registerCommands } from "./commands.ts";
+
+const proofClient = new ProofClient();
+
+let slackApp: App | null = null;
+
+export function isSlackEnabled(): boolean {
+  return Boolean(process.env.SLACK_BOT_TOKEN && process.env.SLACK_SIGNING_SECRET);
+}
+
+export function initSlack(expressApp: Express): App | null {
+  if (!isSlackEnabled()) {
+    console.log("Slack: disabled (SLACK_BOT_TOKEN not set)");
+    return null;
+  }
+
+  const receiver = new ExpressReceiver({
+    signingSecret: process.env.SLACK_SIGNING_SECRET!,
+    app: expressApp,
+    endpoints: "/slack/events",
+  });
+
+  slackApp = new App({
+    token: process.env.SLACK_BOT_TOKEN,
+    receiver,
+  });
+
+  registerCommands(slackApp);
+
+  // Listen for replies to bot messages → post as Proof comments
+  slackApp.event("message", async ({ event, client }) => {
+    // Only handle threaded replies (messages with thread_ts different from ts)
+    if (!("thread_ts" in event) || !event.thread_ts || event.thread_ts === event.ts) return;
+    if (!("text" in event) || !event.text) return;
+
+    // Find the parent message to get the thread ID
+    try {
+      const result = await client.conversations.history({
+        channel: event.channel,
+        latest: event.thread_ts,
+        inclusive: true,
+        limit: 1,
+      });
+
+      const parentMsg = result.messages?.[0];
+      if (!parentMsg?.blocks) return;
+
+      // Look for a thread slug in the parent message's action URL
+      const actionBlock = parentMsg.blocks.find(
+        (b) => b.type === "actions"
+      ) as { elements?: Array<{ url?: string }> } | undefined;
+      const url = actionBlock?.elements?.[0]?.url;
+      if (!url) return;
+
+      const slugMatch = url.match(/\/d\/([^?]+)/);
+      if (!slugMatch) return;
+
+      const slug = slugMatch[1];
+      const thread = ThreadStore.findBySlug(slug!);
+      if (!thread) return;
+
+      // Post the Slack reply as a comment in the Proof doc
+      const username = ("user" in event && event.user) ? event.user : "slack-user";
+      await proofClient.addComment(thread.slug, {
+        by: `slack:${username}`,
+        quote: "",
+        text: event.text,
+      });
+    } catch (err) {
+      console.error("Slack reply → Proof comment error:", err);
+    }
+  });
+
+  // Acknowledge button clicks
+  slackApp.action("open_proof", async ({ ack }) => {
+    await ack();
+  });
+
+  console.log("Slack: enabled");
+  return slackApp;
+}
+
+/** Notify Slack channel about a new high-priority thread. */
+export async function notifyThreadCreated(
+  thread: NonNullable<ReturnType<typeof ThreadStore.findById>>
+): Promise<void> {
+  if (!slackApp || !thread) return;
+
+  const shouldNotify =
+    thread.tags.includes("incident") || thread.status === "escalated";
+  if (!shouldNotify) return;
+
+  const channel = process.env.SLACK_CHANNEL ?? "#incidents";
+
+  try {
+    await slackApp.client.chat.postMessage({
+      channel,
+      text: `New thread: ${thread.title}`,
+      blocks: threadCard(thread),
+    });
+  } catch (err) {
+    console.error("Slack notification error:", err);
+  }
+}

--- a/server/slack/slack.test.ts
+++ b/server/slack/slack.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "bun:test";
+import { threadCard, queueTable } from "./formatters.ts";
+import { isSlackEnabled } from "./slack-app.ts";
+import type { Thread } from "../thread-store.ts";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: "t1",
+    slug: "slug-1",
+    accessToken: "tok",
+    ownerSecret: "secret",
+    title: "Test Thread",
+    status: "open",
+    tags: [],
+    createdBy: "user-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    lastEventId: 0,
+    priorityCache: null,
+    priorityCachedAt: null,
+    ...overrides,
+  };
+}
+
+describe("formatters", () => {
+  describe("threadCard", () => {
+    test("returns Block Kit blocks", () => {
+      const blocks = threadCard(makeThread());
+      expect(blocks.length).toBeGreaterThan(0);
+      expect(blocks[0]!.type).toBe("header");
+    });
+
+    test("includes priority reason in context block", () => {
+      const blocks = threadCard({
+        ...makeThread(),
+        priority: { score: 85, reason: "Critical incident" },
+      });
+      const context = blocks.find((b) => b.type === "context");
+      expect(context).toBeDefined();
+    });
+
+    test("includes actions with Proof URL", () => {
+      const blocks = threadCard(makeThread({ slug: "my-slug", accessToken: "my-tok" }));
+      const actions = blocks.find((b) => b.type === "actions") as { elements: Array<{ url: string }> };
+      expect(actions).toBeDefined();
+      expect(actions.elements[0]!.url).toContain("my-slug");
+      expect(actions.elements[0]!.url).toContain("my-tok");
+    });
+  });
+
+  describe("queueTable", () => {
+    test("returns empty message for no threads", () => {
+      expect(queueTable([])).toBe("No threads in the queue.");
+    });
+
+    test("formats thread list", () => {
+      const result = queueTable([
+        { ...makeThread({ title: "Thread A" }), priority: { score: 90, reason: "Urgent" } },
+        { ...makeThread({ title: "Thread B" }), priority: { score: 40, reason: "Low" } },
+      ]);
+      expect(result).toContain("Thread A");
+      expect(result).toContain("Thread B");
+      expect(result).toContain("90");
+    });
+  });
+});
+
+describe("isSlackEnabled", () => {
+  test("returns false when env vars not set", () => {
+    // In test env, SLACK_BOT_TOKEN should not be set
+    expect(isSlackEnabled()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Added Slack Bolt SDK integration, **gracefully disabled** when `SLACK_BOT_TOKEN` is not set
- **Notifications**: Block Kit card posted to channel when `incident`-tagged or `escalated` thread is created
- **Slash commands**: `/pq list [profile]`, `/pq open <id>`, `/pq create <title>`
- **Reply bridging**: Slack thread replies to bot messages are posted as comments in the Proof doc
- Block Kit formatters for thread cards and queue tables

## Env Vars
```
SLACK_BOT_TOKEN=xoxb-...
SLACK_SIGNING_SECRET=...
SLACK_CHANNEL=#incidents
```

## Key Files
| File | Purpose |
|------|---------|
| `server/slack/slack-app.ts` | Bolt app init, notifications, reply bridging |
| `server/slack/commands.ts` | `/pq` slash command handler |
| `server/slack/formatters.ts` | Block Kit card + queue table formatters |
| `server/slack/slack.test.ts` | 6 tests for formatters + graceful disable |

## Test plan
- [ ] `bun test` — 56 tests pass across 8 files
- [ ] `bun run typecheck` — no errors
- [ ] Server starts cleanly without `SLACK_BOT_TOKEN` (logs "Slack: disabled")
- [ ] With Slack config: incident thread triggers notification card
- [ ] `/pq list sre` returns ranked queue in Slack
- [ ] Slack reply → Proof comment bridging works

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)