### PR TITLE
feat: autonomous agent work loop with document editing

### DIFF
--- a/server/agents/research-agent.ts
+++ b/server/agents/research-agent.ts
@@ -1,0 +1,118 @@
+import {
+  WorkLoopAgent,
+  type AgentAction,
+  type WorkLoopContext,
+} from "./work-loop-agent.ts";
+import type {
+  AgentMentionEvent,
+  AgentThreadCreatedEvent,
+} from "./types.ts";
+import type { Thread } from "../thread-store.ts";
+
+export class ResearchAgent extends WorkLoopAgent {
+  readonly name = "research-agent";
+
+  constructor() {
+    super({
+      maxIterations: 2,
+      cooldownMs: 3_000,
+    });
+  }
+
+  protected override shouldActivate(thread: Thread): boolean {
+    return thread.tags.includes("incident") || thread.tags.includes("research");
+  }
+
+  protected override buildSystemPrompt(): string {
+    return `You are a research agent that helps teams handle incidents and investigations.
+Your job is to read the current document state and propose structured improvements as suggestions.
+
+You output a JSON array of actions. Each action has:
+- "type": one of "suggest_insert", "suggest_replace", "comment", "done"
+- "quote": (for suggest_replace only) the exact text in the document to replace
+- "content": the new content to insert or the comment text
+- "reasoning": brief explanation of why
+
+Guidelines:
+- For new documents with minimal content, use "suggest_insert" to add structured sections
+- For documents that already have content, use "suggest_replace" to improve specific sections
+- Use "comment" to explain what you're doing or ask questions
+- Use "done" when the document is already well-structured
+- Be concise and actionable
+- Never fabricate specific details — use placeholders like "[TBD]" for unknown specifics`;
+  }
+
+  protected override async think(context: WorkLoopContext): Promise<AgentAction[]> {
+    const { thread, state, snapshot, iteration, previousActions } = context;
+
+    const docContent = state.markdown || "(empty document)";
+    const blocks = snapshot.blocks
+      .map((b) => `[${b.ref}] ${b.markdown}`)
+      .join("\n");
+
+    const previousSummary =
+      previousActions.length > 0
+        ? `\n\nPrevious actions taken:\n${previousActions.map((a) => `- ${a.type}: ${a.reasoning ?? a.content.slice(0, 80)}`).join("\n")}`
+        : "";
+
+    const userPrompt = `Thread: "${thread.title}"
+Tags: ${thread.tags.join(", ") || "none"}
+Status: ${thread.status}
+Created by: ${thread.createdBy}
+Iteration: ${iteration + 1}
+
+Current document content:
+---
+${docContent}
+---
+
+Document blocks:
+${blocks || "(no blocks)"}
+${previousSummary}
+
+Based on the current state, what actions should be taken to improve this document?
+For incident threads, ensure there is: a timeline, impact assessment, root cause hypothesis, and action items.
+For research threads, ensure there is: context, key findings, open questions, and next steps.
+
+Respond with ONLY a JSON array of actions.`;
+
+    const response = await this.callLLM(this.buildSystemPrompt(), userPrompt);
+    return this.parseActions(response);
+  }
+
+  override async onThreadCreated(event: AgentThreadCreatedEvent): Promise<void> {
+    const { thread } = event;
+    if (!this.shouldActivate(thread)) return;
+
+    await this.addComment(
+      thread,
+      `**Research agent activated** — I'll analyze this thread and propose structured content as suggestions. Accept or reject them inline in the editor.`
+    );
+
+    // Run work loop asynchronously
+    this.runLoop(thread).catch((err) => {
+      console.error(`${this.name}: work loop failed for ${thread.id}:`, err);
+    });
+  }
+
+  override async onMention(event: AgentMentionEvent): Promise<void> {
+    const { thread } = event;
+
+    if (this.isRunning(thread.id)) {
+      await this.addComment(
+        thread,
+        `I'm already working on this thread. Please wait for my current analysis to complete.`
+      );
+      return;
+    }
+
+    await this.addComment(
+      thread,
+      `**Research agent re-activated** — Running another analysis pass on this document.`
+    );
+
+    this.runLoop(thread).catch((err) => {
+      console.error(`${this.name}: work loop failed for ${thread.id}:`, err);
+    });
+  }
+}

--- a/server/agents/work-loop-agent.test.ts
+++ b/server/agents/work-loop-agent.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect } from "bun:test";
+import {
+  WorkLoopAgent,
+  type AgentAction,
+  type WorkLoopContext,
+} from "./work-loop-agent.ts";
+import { ResearchAgent } from "./research-agent.ts";
+import type { Thread } from "../thread-store.ts";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: "t1",
+    slug: "slug-1",
+    accessToken: "tok",
+    ownerSecret: "secret",
+    title: "Test Thread",
+    status: "open",
+    tags: [],
+    createdBy: "user-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    lastEventId: 0,
+    priorityCache: null,
+    priorityCachedAt: null,
+    ...overrides,
+  };
+}
+
+// Concrete test implementation of WorkLoopAgent
+class TestWorkLoopAgent extends WorkLoopAgent {
+  readonly name = "test-loop-agent";
+  thinkCalls: WorkLoopContext[] = [];
+  actionsToReturn: AgentAction[] = [];
+
+  protected override buildSystemPrompt(): string {
+    return "test system prompt";
+  }
+
+  protected override async think(context: WorkLoopContext): Promise<AgentAction[]> {
+    this.thinkCalls.push(context);
+    return this.actionsToReturn;
+  }
+}
+
+describe("WorkLoopAgent", () => {
+  test("parseActions handles valid JSON", () => {
+    const agent = new TestWorkLoopAgent();
+    const actions = agent["parseActions"](
+      `[{"type":"comment","content":"Hello"},{"type":"done","content":""}]`
+    );
+    expect(actions).toHaveLength(2);
+    expect(actions[0]!.type).toBe("comment");
+    expect(actions[1]!.type).toBe("done");
+  });
+
+  test("parseActions extracts JSON from surrounding text", () => {
+    const agent = new TestWorkLoopAgent();
+    const actions = agent["parseActions"](
+      `Here are my actions:\n[{"type":"suggest_insert","content":"## Timeline"}]\nDone.`
+    );
+    expect(actions).toHaveLength(1);
+    expect(actions[0]!.type).toBe("suggest_insert");
+  });
+
+  test("parseActions returns empty for invalid input", () => {
+    const agent = new TestWorkLoopAgent();
+    expect(agent["parseActions"]("no json here")).toEqual([]);
+    expect(agent["parseActions"]("[invalid}")).toEqual([]);
+  });
+
+  test("parseActions filters invalid action types", () => {
+    const agent = new TestWorkLoopAgent();
+    const actions = agent["parseActions"](
+      `[{"type":"comment","content":"ok"},{"type":"invalid_type","content":"bad"}]`
+    );
+    expect(actions).toHaveLength(1);
+    expect(actions[0]!.type).toBe("comment");
+  });
+
+  test("isRunning tracks active loops", () => {
+    const agent = new TestWorkLoopAgent();
+    expect(agent.isRunning("t1")).toBe(false);
+    expect(agent.activeLoops).toEqual([]);
+  });
+
+  test("prevents concurrent loops on same thread", async () => {
+    const agent = new TestWorkLoopAgent();
+    // Set actionsToReturn to done immediately
+    agent.actionsToReturn = [{ type: "done", content: "" }];
+
+    // Since think returns done, loop finishes fast
+    // We can't easily test concurrency without mocking ProofClient,
+    // but we can verify the mechanism exists
+    expect(agent.isRunning("t1")).toBe(false);
+  });
+
+  test("config defaults", () => {
+    const agent = new TestWorkLoopAgent();
+    expect(agent["config"].maxIterations).toBe(3);
+    expect(agent["config"].cooldownMs).toBe(2000);
+  });
+
+  test("config override", () => {
+    const agent = new TestWorkLoopAgent({ maxIterations: 5, cooldownMs: 500 });
+    expect(agent["config"].maxIterations).toBe(5);
+    expect(agent["config"].cooldownMs).toBe(500);
+  });
+});
+
+describe("ResearchAgent", () => {
+  const agent = new ResearchAgent();
+
+  test("has correct name", () => {
+    expect(agent.name).toBe("research-agent");
+  });
+
+  test("activates for incident-tagged threads", () => {
+    expect(agent["shouldActivate"](makeThread({ tags: ["incident"] }))).toBe(true);
+  });
+
+  test("activates for research-tagged threads", () => {
+    expect(agent["shouldActivate"](makeThread({ tags: ["research"] }))).toBe(true);
+  });
+
+  test("does not activate for unrelated threads", () => {
+    expect(agent["shouldActivate"](makeThread({ tags: ["bug"] }))).toBe(false);
+    expect(agent["shouldActivate"](makeThread())).toBe(false);
+  });
+
+  test("has onThreadCreated handler", () => {
+    expect(agent.onThreadCreated).toBeDefined();
+  });
+
+  test("has onMention handler", () => {
+    expect(agent.onMention).toBeDefined();
+  });
+
+  test("config uses 2 max iterations", () => {
+    expect(agent["config"].maxIterations).toBe(2);
+  });
+
+  test("builds system prompt", () => {
+    const prompt = agent["buildSystemPrompt"]();
+    expect(prompt).toContain("research agent");
+    expect(prompt).toContain("suggest_insert");
+    expect(prompt).toContain("suggest_replace");
+  });
+});

--- a/server/agents/work-loop-agent.ts
+++ b/server/agents/work-loop-agent.ts
@@ -1,0 +1,236 @@
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  ProofClient,
+  type DocumentState,
+  type DocumentSnapshot,
+} from "../proof-client.ts";
+import type { Thread } from "../thread-store.ts";
+import { BaseAgent } from "./base-agent.ts";
+import type {
+  AgentMentionEvent,
+  AgentScanEvent,
+  AgentThreadCreatedEvent,
+} from "./types.ts";
+
+const proofClient = new ProofClient();
+const anthropic = new Anthropic();
+
+export type ActionType =
+  | "suggest_replace"
+  | "suggest_insert"
+  | "comment"
+  | "done";
+
+export interface AgentAction {
+  type: ActionType;
+  /** For suggest_replace: text in the doc to replace */
+  quote?: string;
+  /** The new/inserted content */
+  content: string;
+  /** Explanation of why this action is being taken */
+  reasoning?: string;
+}
+
+export interface WorkLoopContext {
+  thread: Thread;
+  state: DocumentState;
+  snapshot: DocumentSnapshot;
+  iteration: number;
+  previousActions: AgentAction[];
+}
+
+export interface WorkLoopConfig {
+  maxIterations: number;
+  cooldownMs: number;
+  model: string;
+}
+
+const DEFAULT_CONFIG: WorkLoopConfig = {
+  maxIterations: 3,
+  cooldownMs: 2_000,
+  model: "claude-sonnet-4-20250514",
+};
+
+export abstract class WorkLoopAgent extends BaseAgent {
+  protected config: WorkLoopConfig;
+  private running = new Set<string>();
+
+  constructor(config: Partial<WorkLoopConfig> = {}) {
+    super();
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Core thinking method — given the document context, decide what actions to take.
+   * Subclasses must implement this.
+   */
+  protected abstract think(context: WorkLoopContext): Promise<AgentAction[]>;
+
+  /**
+   * Build the system prompt for this agent's domain.
+   * Subclasses must implement this.
+   */
+  protected abstract buildSystemPrompt(): string;
+
+  /**
+   * Determine if this agent should activate for a given thread.
+   * Subclasses can override for filtering.
+   */
+  protected shouldActivate(_thread: Thread): boolean {
+    return true;
+  }
+
+  /**
+   * Run the full work loop: read → think → act → iterate.
+   */
+  async runLoop(thread: Thread): Promise<void> {
+    if (this.running.has(thread.id)) return; // prevent concurrent loops
+    this.running.add(thread.id);
+
+    try {
+      await this.updatePresence(thread, "working", "Running work loop");
+
+      const previousActions: AgentAction[] = [];
+
+      for (let i = 0; i < this.config.maxIterations; i++) {
+        // 1. READ
+        let state: DocumentState;
+        let snapshot: DocumentSnapshot;
+        try {
+          state = await proofClient.getState(thread.slug, thread.accessToken);
+          snapshot = await proofClient.getSnapshot(
+            thread.slug,
+            thread.accessToken
+          );
+        } catch (err) {
+          console.error(`${this.name}: failed to read doc state:`, err);
+          break;
+        }
+
+        // 2. THINK
+        const context: WorkLoopContext = {
+          thread,
+          state,
+          snapshot,
+          iteration: i,
+          previousActions,
+        };
+
+        let actions: AgentAction[];
+        try {
+          actions = await this.think(context);
+        } catch (err) {
+          console.error(`${this.name}: think failed:`, err);
+          break;
+        }
+
+        if (actions.length === 0 || actions.every((a) => a.type === "done")) {
+          break;
+        }
+
+        // 3. ACT
+        for (const action of actions) {
+          try {
+            await this.executeAction(thread, action);
+            previousActions.push(action);
+          } catch (err) {
+            console.error(
+              `${this.name}: action ${action.type} failed:`,
+              err
+            );
+          }
+        }
+
+        // 4. COOLDOWN
+        if (i < this.config.maxIterations - 1) {
+          await new Promise((r) => setTimeout(r, this.config.cooldownMs));
+        }
+      }
+
+      await this.updatePresence(thread, "idle", "Work loop complete");
+    } finally {
+      this.running.delete(thread.id);
+    }
+  }
+
+  private async executeAction(
+    thread: Thread,
+    action: AgentAction
+  ): Promise<void> {
+    switch (action.type) {
+      case "suggest_replace":
+        if (!action.quote) {
+          console.warn(`${this.name}: suggest_replace without quote, using comment instead`);
+          await this.addComment(thread, action.content);
+          return;
+        }
+        await proofClient.suggestReplace(thread.slug, {
+          by: `ai:${this.name}`,
+          quote: action.quote,
+          content: action.content,
+        });
+        break;
+
+      case "suggest_insert":
+        await proofClient.suggestInsert(thread.slug, {
+          by: `ai:${this.name}`,
+          content: action.content,
+        });
+        break;
+
+      case "comment":
+        await this.addComment(thread, action.content);
+        break;
+
+      case "done":
+        break;
+    }
+  }
+
+  /**
+   * Helper: call Claude with structured output to generate actions.
+   */
+  protected async callLLM(
+    systemPrompt: string,
+    userPrompt: string
+  ): Promise<string> {
+    const response = await anthropic.messages.create({
+      model: this.config.model,
+      max_tokens: 2048,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userPrompt }],
+    });
+
+    return response.content[0]?.type === "text" ? response.content[0].text : "";
+  }
+
+  /**
+   * Parse a JSON array of actions from LLM output.
+   */
+  protected parseActions(text: string): AgentAction[] {
+    const match = text.match(/\[[\s\S]*\]/);
+    if (!match) return [];
+    try {
+      const parsed = JSON.parse(match[0]) as AgentAction[];
+      return parsed.filter(
+        (a) =>
+          a.type &&
+          ["suggest_replace", "suggest_insert", "comment", "done"].includes(
+            a.type
+          )
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  /** Check if a loop is already running for a thread. */
+  isRunning(threadId: string): boolean {
+    return this.running.has(threadId);
+  }
+
+  /** Get all thread IDs currently in a work loop. */
+  get activeLoops(): string[] {
+    return [...this.running];
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import { ScheduledScanner } from "./agents/scheduled-scanner.ts";
 import { AgentRegistry } from "./agents/registry.ts";
 import { TriageAgent } from "./agents/triage-agent.ts";
 import { SreAgent } from "./agents/sre-agent.ts";
+import { ResearchAgent } from "./agents/research-agent.ts";
 import { initSlack } from "./slack/slack-app.ts";
 
 // Initialize DB (runs migrations on import)
@@ -18,6 +19,7 @@ const proofClient = new ProofClient();
 // Register agents
 AgentRegistry.register(new TriageAgent());
 AgentRegistry.register(new SreAgent());
+AgentRegistry.register(new ResearchAgent());
 
 const poller = initEventPoller(proofClient);
 poller.onEvent(handleMentions);

--- a/server/proof-client.ts
+++ b/server/proof-client.ts
@@ -15,7 +15,7 @@ interface CreateDocumentResult {
   docId: string;
 }
 
-interface DocumentState {
+export interface DocumentState {
   slug: string;
   markdown: string;
   title: string;
@@ -50,6 +50,38 @@ interface AddCommentOptions {
   by: string;
   quote: string;
   text: string;
+}
+
+export interface DocumentSnapshot {
+  revision: number;
+  blocks: Array<{ ref: string; markdown: string; node_type: string }>;
+}
+
+export interface SuggestReplaceOptions {
+  by: string;
+  quote: string;
+  content: string;
+}
+
+export interface SuggestInsertOptions {
+  by: string;
+  after?: string;
+  content: string;
+}
+
+export interface EditBlockOperation {
+  op: "replace_block" | "insert_after" | "insert_before" | "delete_block";
+  ref?: string;
+  afterRef?: string;
+  beforeRef?: string;
+  markdown?: string;
+}
+
+export interface EditBlocksOptions {
+  by: string;
+  baseRevision: number;
+  operations: EditBlockOperation[];
+  agentId?: string;
 }
 
 export class ProofClient {
@@ -135,6 +167,67 @@ export class ProofClient {
 
     if (!res.ok) {
       throw new Error(`addComment failed: ${res.status} ${res.statusText}`);
+    }
+  }
+
+  async getSnapshot(slug: string, token?: string): Promise<DocumentSnapshot> {
+    const url = new URL(`${this.baseUrl}/documents/${slug}/snapshot`);
+    if (token) url.searchParams.set("token", token);
+
+    const res = await fetch(url.toString());
+
+    if (!res.ok) {
+      throw new Error(`getSnapshot failed: ${res.status} ${res.statusText}`);
+    }
+
+    return res.json() as Promise<DocumentSnapshot>;
+  }
+
+  async suggestReplace(
+    slug: string,
+    options: SuggestReplaceOptions
+  ): Promise<void> {
+    const res = await fetch(
+      `${this.baseUrl}/documents/${slug}/marks/suggest-replace`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(options),
+      }
+    );
+
+    if (!res.ok) {
+      throw new Error(`suggestReplace failed: ${res.status} ${res.statusText}`);
+    }
+  }
+
+  async suggestInsert(
+    slug: string,
+    options: SuggestInsertOptions
+  ): Promise<void> {
+    const res = await fetch(
+      `${this.baseUrl}/documents/${slug}/marks/suggest-insert`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(options),
+      }
+    );
+
+    if (!res.ok) {
+      throw new Error(`suggestInsert failed: ${res.status} ${res.statusText}`);
+    }
+  }
+
+  async editBlocks(slug: string, options: EditBlocksOptions): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/documents/${slug}/edit/v2`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(options),
+    });
+
+    if (!res.ok) {
+      throw new Error(`editBlocks failed: ${res.status} ${res.statusText}`);
     }
   }
 


### PR DESCRIPTION
## Summary
The single biggest architectural leap for proof-queue: agents go from **passive commenters** to **autonomous co-authors** that read documents, reason about what's needed, and propose inline changes as suggestions — keeping humans in control through Proof's accept/reject flow.

### What changed
- **ProofClient** extended with `suggestReplace()`, `suggestInsert()`, `getSnapshot()`, `editBlocks()` — the full editing API surface
- **WorkLoopAgent** base class implementing the `read → think → act → wait` cycle:
  - Abstract `think()` for domain-specific reasoning
  - Configurable `maxIterations` and `cooldownMs`
  - Concurrent loop prevention per thread
  - `callLLM()` + `parseActions()` helpers for structured output
  - Action types: `suggest_replace`, `suggest_insert`, `comment`, `done`
- **ResearchAgent** — first WorkLoopAgent implementation:
  - Activates on `incident` or `research` tagged threads
  - Reads document state via `getState()` + `getSnapshot()`
  - Calls Claude to generate structured content (timeline, impact, root cause, action items)
  - Proposes all changes as **inline suggestions** — humans accept/reject in the editor
  - Re-triggerable via `@research-agent` mention

### The flow
```
1. Incident thread created with tag "incident"
2. ResearchAgent activates, reads empty/minimal doc
3. Claude analyzes context, generates structured post-mortem sections
4. Sections proposed as inline suggestions in Proof editor
5. Human reviews: accepts useful parts, rejects/edits others
6. Agent can re-run on @mention with updated context
```

## Key Files
| File | Purpose |
|------|---------|
| `server/agents/work-loop-agent.ts` | Base class: read → think → act → wait |
| `server/agents/research-agent.ts` | Incident/research domain agent |
| `server/proof-client.ts` | Extended with suggestion + edit APIs |
| `server/agents/work-loop-agent.test.ts` | 16 tests |

## Test plan
- [ ] `bun test` — 72 tests pass across 9 files
- [ ] `bun run typecheck` — no errors
- [ ] With docker-compose + `ANTHROPIC_API_KEY`: create incident thread → research-agent proposes structured content
- [ ] Suggestions appear inline in Proof editor
- [ ] `@research-agent` re-triggers analysis
- [ ] Existing agents (triage, SRE) unaffected

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)